### PR TITLE
Rename dynamic canvas container names

### DIFF
--- a/dynamic_canvas/dynamicCanvas.js
+++ b/dynamic_canvas/dynamicCanvas.js
@@ -32,12 +32,12 @@ export class DynamicCanvas {
     }
 
     createDOM() {
-        // Main container
-        this.container = this.createEl('div', 'dc-container');
+        // Main viewport array container
+        this.viewportArray = this.createEl('div', 'viewport-array');
         // Area where panels (canvases or splits) get rendered
-        this.canvasArea = this.createEl('div', 'dc-canvas-area');
-        this.container.appendChild(this.canvasArea);
-        document.body.appendChild(this.container);
+        this.viewport = this.createEl('div', 'viewport');
+        this.viewportArray.appendChild(this.viewport);
+        document.body.appendChild(this.viewportArray);
     }
 
     bindUIAutohide() {
@@ -54,9 +54,9 @@ export class DynamicCanvas {
 
     render() {
         // Clear previous contents
-        this.canvasArea.innerHTML = '';
+        this.viewport.innerHTML = '';
         // Recursively render starting from root
-        this.renderNode(this.layoutTree, this.canvasArea);
+        this.renderNode(this.layoutTree, this.viewport);
     }
 
     renderNode(node, container) {

--- a/dynamic_canvas/dynamic_canvas.css
+++ b/dynamic_canvas/dynamic_canvas.css
@@ -1,11 +1,11 @@
 /* 1. Top‑level containers (renamed) */
-.dc-container {
+.viewport-array {
     display: flex;
     height: 100vh;
     width: 100vw;
 }
 
-.dc-canvas-area {
+.viewport {
     flex: 1;
     display: flex;
     position: relative;

--- a/examples/dynamic_canvas_layout.html
+++ b/examples/dynamic_canvas_layout.html
@@ -19,13 +19,13 @@
             color: white;
         }
 
-        .container {
+        .viewport-array {
             display: flex;
             height: 100vh;
             width: 100vw;
         }
 
-        .canvas-area {
+        .viewport {
             flex: 1;
             display: flex;
             position: relative;
@@ -187,8 +187,8 @@
     </style>
 </head>
 <body>
-    <div class="container">
-        <div class="canvas-area" id="canvasArea"></div>
+    <div class="viewport-array">
+        <div class="viewport" id="viewport"></div>
     </div>
 
     <div class="info">
@@ -467,9 +467,9 @@
         }
 
         function render() {
-            const canvasArea = document.getElementById('canvasArea');
-            canvasArea.innerHTML = '';
-            renderNode(layoutTree, canvasArea);
+            const viewport = document.getElementById('viewport');
+            viewport.innerHTML = '';
+            renderNode(layoutTree, viewport);
         }
 
         // Initial render


### PR DESCRIPTION
## Summary
- rename top-level classes to `viewport-array` and `viewport`
- update DynamicCanvas implementation to use new class names
- adjust example to reflect the new naming

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684cc9ac853c8329b7589f2a7afe9c72