### PR TITLE
Inline styles with style property

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,16 @@ import { DynamicCanvas } from './dynamic_canvas/dynamicCanvas.js';
 import { AudioSamplePuller, MusicPlayer } from './audioPlayer/audioPlayer.js';
 import { STFTVisualizer } from './STFTVisualizer/STFTVisualizer.js';
 
+// Apply basic global styling without a stylesheet
+document.body.style.margin = '0';
+document.body.style.padding = '0';
+document.body.style.boxSizing = 'border-box';
+document.body.style.fontFamily = "'Segoe UI', Tahoma, Geneva, Verdana, sans-serif";
+document.body.style.height = '100vh';
+document.body.style.overflow = 'hidden';
+document.body.style.background = '#1a1a1a';
+document.body.style.color = 'white';
+
 // TODO:
 // make favicon with https://favicon.io/favicon-converter/
 // don't rebuild canvases

--- a/audioPlayer/audioPlayer.js
+++ b/audioPlayer/audioPlayer.js
@@ -49,6 +49,7 @@ export class AudioSamplePuller {
   }
 }
 
+
 export class MusicPlayer {
   /**
    * @param {HTMLDivElement} containerDiv
@@ -61,7 +62,7 @@ export class MusicPlayer {
       throw new Error('MusicPlayer: constructor argument must be a <div>.');
     }
     this.container = containerDiv;
-    this.container.classList.add('music-player-container');
+    this.container.style.fontFamily = 'sans-serif';
     this.workletURL = workletURL;
     this.audioContext = null;
     this.samplePuller = null;
@@ -71,11 +72,6 @@ export class MusicPlayer {
     this.audioBufferInfo = null;
     this._buildUI();
 
-    // load css
-    const link = document.createElement('link');
-    link.rel = 'stylesheet';
-    link.href = './audioPlayer/styles.css';
-    document.head.appendChild(link);
   }
 
   _buildUI() {
@@ -83,25 +79,42 @@ export class MusicPlayer {
     this.fileInput = document.createElement('input');
     this.fileInput.type = 'file';
     this.fileInput.accept = 'audio/*';
-    this.fileInput.classList.add('music-player-file-input');
+    this.fileInput.style.marginBottom = '8px';
     this.fileInput.addEventListener('change', e => this._onFileSelected(e));
     this.container.appendChild(this.fileInput);
 
     // — Play/Pause toggle & Stop buttons —
     this.controlsDiv = document.createElement('div');
-    this.controlsDiv.classList.add('music-player-controls');
+    this.controlsDiv.style.marginTop = '8px';
 
     this.playPauseBtn = document.createElement('button');
     this.playPauseBtn.textContent = 'Play';
     this.playPauseBtn.disabled = true;
-    this.playPauseBtn.classList.add('music-player-btn');
+    Object.assign(this.playPauseBtn.style, {
+      background: '#222',
+      color: '#fff',
+      border: 'none',
+      padding: '6px 12px',
+      fontSize: '14px',
+      borderRadius: '4px',
+      cursor: 'pointer'
+    });
     this.playPauseBtn.addEventListener('click', () => this._togglePlayPause());
     this.controlsDiv.appendChild(this.playPauseBtn);
 
     this.stopBtn = document.createElement('button');
     this.stopBtn.textContent = 'Stop';
     this.stopBtn.disabled = true;
-    this.stopBtn.classList.add('music-player-btn');
+    Object.assign(this.stopBtn.style, {
+      background: '#222',
+      color: '#fff',
+      border: 'none',
+      padding: '6px 12px',
+      fontSize: '14px',
+      borderRadius: '4px',
+      cursor: 'pointer',
+      marginLeft: '4px'
+    });
     this.stopBtn.addEventListener('click', () => this.stop());
     this.controlsDiv.appendChild(this.stopBtn);
 
@@ -115,23 +128,23 @@ export class MusicPlayer {
     this.slider.value = 0;
     this.slider.step = 0.01;
     this.slider.disabled = true;
-    this.slider.classList.add('music-player-slider');
+    Object.assign(this.slider.style, { width: '100%', marginTop: '8px' });
     this.slider.addEventListener('input', () => this._onScrub());
     this.container.appendChild(this.slider);
 
     // — Time display (MM:SS / MM:SS) —
     this.timeDisplay = document.createElement('div');
     this.timeDisplay.textContent = '00:00 / 00:00';
-    this.timeDisplay.classList.add('music-player-time-display');
+    Object.assign(this.timeDisplay.style, { textAlign: 'right', fontFamily: 'monospace', marginTop: '4px' });
     this.container.appendChild(this.timeDisplay);
 
     // — Volume slider —
     this.volumeContainer = document.createElement('div');
-    this.volumeContainer.classList.add('music-player-volume-container');
+    Object.assign(this.volumeContainer.style, { marginTop: '8px', display: 'flex', alignItems: 'center' });
 
     const volLabel = document.createElement('label');
     volLabel.textContent = 'Volume';
-    volLabel.classList.add('music-player-volume-label');
+    Object.assign(volLabel.style, { marginRight: '8px', fontSize: '14px' });
     this.volumeContainer.appendChild(volLabel);
 
     this.volumeSlider = document.createElement('input');
@@ -141,7 +154,7 @@ export class MusicPlayer {
     this.volumeSlider.step = 0.01;
     this.volumeSlider.value = 1;
     this.volumeSlider.disabled = true;
-    this.volumeSlider.classList.add('music-player-volume-slider');
+    this.volumeSlider.style.flex = '1';
     this.volumeSlider.addEventListener('input', () => {
       if (this.gainNode) {
         this.gainNode.gain.value = parseFloat(this.volumeSlider.value);
@@ -154,7 +167,14 @@ export class MusicPlayer {
     // — Details panel —
     this.detailsPre = document.createElement('pre');
     this.detailsPre.textContent = 'No track loaded.';
-    this.detailsPre.classList.add('music-player-details');
+    Object.assign(this.detailsPre.style, {
+      marginTop: '8px',
+      padding: '8px',
+      fontFamily: 'Menlo, monospace',
+      fontSize: '13px',
+      whiteSpace: 'pre-wrap',
+      borderRadius: '4px'
+    });
     this.container.appendChild(this.detailsPre);
   }
 
@@ -326,18 +346,5 @@ export class MusicPlayer {
 }
 
 // --- USAGE EXAMPLE ---
-// 1) Include both files in your HTML:
-//
-//    <link rel="stylesheet" href="styles.css" />
-//    <script src="music-player.js"></script>
-//
-// 2) Add a container:
-//
-//    <div id="player-container"></div>
-//
-// 3) After DOM loads:
-//
-//    const container = document.getElementById('player-container');
-//    const player = new MusicPlayer(container, './sample-processor.js');
-//
-// No inline styles remain; all appearance is driven by `styles.css`.
+// const container = document.getElementById('player-container');
+// const player = new MusicPlayer(container, './sample-processor.js');

--- a/controlPanel/controlPanel.js
+++ b/controlPanel/controlPanel.js
@@ -1,22 +1,83 @@
 // controlPanel.js
+const STYLE_MAP = {
+    'tab-container': {
+        position: 'fixed',
+        left: '0',
+        top: '0',
+        zIndex: '1000'
+    },
+    'tab': {
+        position: 'absolute',
+        left: '0',
+        top: '0',
+        width: '60px',
+        height: '120px',
+        background: 'linear-gradient(135deg, #ff6b6b, #ee5a24)',
+        borderRadius: '0 0 15px 0',
+        cursor: 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: 'white',
+        fontWeight: 'bold',
+        fontSize: '24px',
+        textAlign: 'center',
+        lineHeight: '1.2',
+        opacity: '0.3',
+        transition: 'all 0.3s ease',
+        boxShadow: '2px 0 10px rgba(0,0,0,0.2)'
+    },
+    'tab-content': {
+        position: 'fixed',
+        left: '-350px',
+        top: '0',
+        width: '350px',
+        height: '100vh',
+        background: '#000',
+        borderRadius: '0 0 20px 0',
+        boxShadow: '5px 0 25px rgba(0,0,0,0.3)',
+        transition: 'left 0.4s cubic-bezier(0.25, 0.8, 0.25, 1)',
+        padding: '30px',
+        zIndex: '999',
+        overflowY: 'auto'
+    },
+    'close-btn': {
+        position: 'absolute',
+        top: '10px',
+        right: '10px',
+        background: 'transparent',
+        border: 'none',
+        fontSize: '24px',
+        cursor: 'pointer',
+        color: '#ccc'
+    },
+    'content': {
+        padding: '15px',
+        background: '#000',
+        color: '#ccc'
+    },
+    'overlay': {
+        position: 'fixed',
+        top: '0',
+        left: '0',
+        width: '100vw',
+        height: '100vh',
+        background: 'rgba(0,0,0,0.5)',
+        opacity: '0',
+        visibility: 'hidden',
+        transition: 'opacity 0.3s'
+    }
+};
+
 export class ControlPanel {
     constructor(options = {}) {
-        this.cssPath = options.cssPath || 'controlPanel/controlPanel.css';
         this.isOpen = false;
         this.init();
     }
 
     init() {
-        this.loadStyles();
         this.createElements();
         this.attachEvents();
-    }
-
-    loadStyles() {
-        const link = document.createElement('link');
-        link.rel = 'stylesheet';
-        link.href = this.cssPath;
-        document.head.appendChild(link);
     }
 
     createElements() {
@@ -52,9 +113,33 @@ export class ControlPanel {
             this.openPanel();
         });
 
+        this.tab.addEventListener('mouseenter', () => {
+            if (!this.isOpen) {
+                this.tab.style.opacity = '1';
+                this.tab.style.transform = 'translateX(5px)';
+                this.tab.style.boxShadow = '4px 0 15px rgba(0,0,0,0.3)';
+            }
+        });
+        this.tab.addEventListener('mouseleave', () => {
+            if (!this.isOpen) {
+                this.tab.style.opacity = '0.3';
+                this.tab.style.transform = '';
+                this.tab.style.boxShadow = '2px 0 10px rgba(0,0,0,0.2)';
+            }
+        });
+
         this.closeBtn.addEventListener('click', e => {
             e.stopPropagation();
             this.closePanel();
+        });
+
+        this.closeBtn.addEventListener('mouseenter', () => {
+            this.closeBtn.style.color = '#fff';
+            this.closeBtn.style.background = '#333';
+        });
+        this.closeBtn.addEventListener('mouseleave', () => {
+            this.closeBtn.style.color = '#ccc';
+            this.closeBtn.style.background = 'transparent';
         });
 
         this.overlay.addEventListener('click', () => this.closePanel());
@@ -76,19 +161,44 @@ export class ControlPanel {
 
     createDetails(summaryText) {
         const details = document.createElement('details');
+        Object.assign(details.style, {
+            marginBottom: '15px',
+            border: '1px solid #444',
+            borderRadius: '8px',
+            overflow: 'hidden'
+        });
+
         const summary = document.createElement('summary');
         summary.textContent = summaryText;
+        Object.assign(summary.style, {
+            background: '#222',
+            padding: '15px',
+            cursor: 'pointer',
+            fontWeight: '600',
+            color: '#fff',
+            borderBottom: '1px solid #444'
+        });
         details.appendChild(summary);
 
         const contentDiv = this.createEl('div', 'content');
-
         details.appendChild(contentDiv);
+
+        details.addEventListener('toggle', () => {
+            if (details.open) {
+                summary.style.background = '#444';
+            } else {
+                summary.style.background = '#222';
+            }
+        });
+
         return [details, contentDiv];
     }
 
     createEl(tag, className = '', id = '', text = '') {
         const el = document.createElement(tag);
-        if (className) el.className = className;
+        if (className && STYLE_MAP[className]) {
+            Object.assign(el.style, STYLE_MAP[className]);
+        }
         if (id) el.id = id;
         if (text) el.textContent = text;
         return el;
@@ -97,20 +207,31 @@ export class ControlPanel {
     createTextEl(tag, text) {
         const el = document.createElement(tag);
         el.textContent = text;
+        if (tag === 'h2') {
+            el.style.color = '#fff';
+            el.style.marginBottom = '20px';
+            el.style.fontSize = '24px';
+        } else if (tag === 'p') {
+            el.style.color = '#ccc';
+            el.style.lineHeight = '1.6';
+            el.style.marginBottom = '15px';
+        }
         return el;
     }
 
     openPanel() {
         this.isOpen = true;
-        this.tabContent.classList.add('open');
-        this.overlay.classList.add('active');
-        this.tab.classList.add('active');
+        this.tabContent.style.left = '0';
+        this.overlay.style.opacity = '1';
+        this.overlay.style.visibility = 'visible';
+        this.tab.style.opacity = '1';
     }
 
     closePanel() {
         this.isOpen = false;
-        this.tabContent.classList.remove('open');
-        this.overlay.classList.remove('active');
-        this.tab.classList.remove('active');
+        this.tabContent.style.left = '-350px';
+        this.overlay.style.opacity = '0';
+        this.overlay.style.visibility = 'hidden';
+        this.tab.style.opacity = '0.3';
     }
 }

--- a/index.html
+++ b/index.html
@@ -4,10 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Signal Analysis</title>
-    <link rel="stylesheet" href="styles.css">
     <script type="module" src="app.js" defer></script>
-</html>
+</head>
 <body>
-    
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move root page styling directly to `app.js`
- convert control panel to use inline style properties
- embed dynamic canvas styles via element.style assignments
- inline music player styling in the constructor and UI builder

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ce599ff5883298539f00011bb7982