### PR TITLE
Integrate audio player controls, volume/time state, and move canvas layout ops into app state

### DIFF
--- a/clojure/src/app/state.cljs
+++ b/clojure/src/app/state.cljs
@@ -18,7 +18,8 @@
          :settings {}}
     :visualizers {:instances {}  ;; {canvas-id -> visualizer instance}}
     :samples {:channels {}}})"
-  (:require [reagent.core :as r]))
+  (:require [reagent.core :as r]
+            [canvas.model :as model]))
 
 ;; Central application state atom
 (defonce app-state
@@ -28,6 +29,8 @@
             :sample-puller nil
             :sample-rate 0
             :duration 0
+            :current-time 0
+            :volume 1.0
             :is-playing false}
     :layout {:root {:type :canvas
                     :id 0
@@ -39,6 +42,10 @@
          :settings {}}
     :visualizers {:instances {}}
     :samples {:channels {}}}))
+
+(defn- canvas-ids
+  [layout-root]
+  (vec (model/get-all-canvas-ids layout-root)))
 
 ;; Dispatch functions for state updates
 (defn dispatch
@@ -52,10 +59,26 @@
     :set-sample-rate
     (let [[rate] args]
       (swap! app-state assoc-in [:audio :sample-rate] rate))
+
+    :set-audio-player
+    (let [[player] args]
+      (swap! app-state assoc-in [:audio :player] player))
+
+    :set-sample-puller
+    (let [[sample-puller] args]
+      (swap! app-state assoc-in [:audio :sample-puller] sample-puller))
     
     :set-duration
     (let [[duration] args]
       (swap! app-state assoc-in [:audio :duration] duration))
+
+    :set-current-time
+    (let [[current-time] args]
+      (swap! app-state assoc-in [:audio :current-time] current-time))
+
+    :set-volume
+    (let [[volume] args]
+      (swap! app-state assoc-in [:audio :volume] volume))
     
     :set-playing
     (let [[playing] args]
@@ -66,25 +89,54 @@
     
     :split-canvas
     (let [[canvas-id orientation] args]
-      ;; Note: Canvas split logic is handled in canvas.view
-      ;; (this is a placeholder for state updates if needed)
-      )
+      (swap! app-state
+             (fn [s]
+               (let [next-id (get-in s [:layout :canvas-counter])
+                     current-layout (get-in s [:layout :root])
+                     new-layout (model/split-canvas current-layout canvas-id orientation next-id)]
+                 (if (nil? new-layout)
+                   s
+                   (-> s
+                       (assoc-in [:layout :root] new-layout)
+                       (update-in [:layout :canvas-counter] inc)))))))
     
     :remove-canvas
     (let [[canvas-id] args]
-      ;; Note: Canvas removal logic is handled in canvas.view
-      ;; (this is a placeholder for state updates if needed)
-      )
+      (swap! app-state
+             (fn [s]
+               (let [current-layout (get-in s [:layout :root])
+                     new-layout (model/remove-canvas current-layout canvas-id)]
+                 (if (nil? new-layout)
+                   s
+                   (let [remaining-ids (set (canvas-ids new-layout))]
+                     (-> s
+                         (assoc-in [:layout :root] new-layout)
+                         (update-in [:visualizers :instances]
+                                    (fn [m]
+                                      (into {}
+                                            (filter (fn [[id _]] (contains? remaining-ids id)) m)))))))))))
     
     :change-visualizer
     (let [[canvas-id visualizer-type] args]
-      ;; Note: Handled in canvas.view
-      )
+      (swap! app-state
+             (fn [s]
+               (-> s
+                   (update-in [:layout :root] model/change-canvas-visualizer canvas-id visualizer-type)
+                   (assoc-in [:visualizers :instances canvas-id]
+                             {:type visualizer-type
+                              :settings (get-in s [:visualizers :instances canvas-id :settings] {})})))))
     
     :update-visualizer-settings
     (let [[canvas-id settings] args]
-      ;; Note: Handled in canvas.view
-      )
+      (swap! app-state
+             (fn [s]
+               (-> s
+                   (update-in [:layout :root] model/update-canvas-settings canvas-id settings)
+                   (update-in [:visualizers :instances canvas-id :settings]
+                              (fn [existing]
+                                (if (fn? settings)
+                                  (settings (or existing {}))
+                                  (merge (or existing {}) settings))))))))
     
     (do
       (.warn js/console "Unknown action:" action))))

--- a/clojure/src/audio/player.cljs
+++ b/clojure/src/audio/player.cljs
@@ -59,6 +59,8 @@
                         ;; Update app state with audio context
                         (state/dispatch :init-audio audio-context)
                         (state/dispatch :set-sample-rate (interop/get-sample-rate audio-context))
+                        (state/dispatch :set-audio-player player)
+                        (state/dispatch :set-sample-puller sp)
                         
                         (resolve player))))
              (.catch reject)))
@@ -93,8 +95,16 @@
                           (fn []
                             (let [duration (interop/get-audio-element-duration audio-element)]
                               (state/dispatch :set-duration duration))
-                            (remove-property audio-element "onloadedmetadata")
+                            (state/dispatch :set-current-time 0)
+                            (set! (.-onloadedmetadata audio-element) nil)
                             (resolve audio-element)))
+                    (set! (.-ontimeupdate audio-element)
+                          (fn []
+                            (state/dispatch :set-current-time
+                                            (interop/get-audio-element-current-time audio-element))))
+                    (set! (.-onended audio-element)
+                          (fn []
+                            (state/dispatch :set-playing false)))
                     
                     ;; Handle load errors
                     (set! (.-onerror audio-element)

--- a/clojure/src/canvas/view.cljs
+++ b/clojure/src/canvas/view.cljs
@@ -4,8 +4,7 @@
    Renders the layout tree as DOM elements with flexbox, canvas elements,
    and interactive controls (split, remove, resize)."
   (:require [reagent.core :as r]
-            [app.state :as state]
-            [canvas.model :as model]))
+            [app.state :as state]))
 
 ;; ============================================================================
 ;; Helper functions
@@ -172,24 +171,9 @@
       :reagent-render
       (fn []
         (let [on-split (fn [canvas-id orientation]
-                         ;; Get next available ID
-                         (let [next-id (state/get-next-canvas-id)]
-                           ;; Update app state with new layout
-                           (swap! state/app-state
-                                  (fn [app-state]
-                                    (let [current-layout (get-in app-state [:layout :root])
-                                          new-layout (model/split-canvas current-layout canvas-id orientation next-id)]
-                                      (assoc-in app-state [:layout :root] new-layout))))))
-              
+                         (state/dispatch :split-canvas canvas-id orientation))
               on-remove (fn [canvas-id]
-                          ;; Update app state by removing canvas
-                          (swap! state/app-state
-                                 (fn [app-state]
-                                   (let [current-layout (get-in app-state [:layout :root])
-                                         new-layout (model/remove-canvas current-layout canvas-id)]
-                                     (if new-layout
-                                       (assoc-in app-state [:layout :root] new-layout)
-                                       app-state)))))]
+                          (state/dispatch :remove-canvas canvas-id))]
           
           [:div.canvas-manager
            {:style {:display "flex"

--- a/clojure/src/ui/control_panel.cljs
+++ b/clojure/src/ui/control_panel.cljs
@@ -2,7 +2,18 @@
   "Control panel UI component for adjusting audio and visualizer settings."
   (:require [reagent.core :as r]
             [app.state :as state]
+            [audio.player :as player]
+            [canvas.model :as canvas-model]
             [visualizers.registry :as registry]))
+
+(defn- canvas-ids-from-layout
+  [node]
+  (cond
+    (nil? node) []
+    (= (:type node) :canvas) [(:id node)]
+    (= (:type node) :split) (concat (canvas-ids-from-layout (:left node))
+                                    (canvas-ids-from-layout (:right node)))
+    :else []))
 
 ;; ============================================================================
 ;; Audio Player Control Component
@@ -11,43 +22,57 @@
 (defn audio-player-controls
   "UI controls for audio playback (file upload, play, pause, seek)."
   []
-  [:div.audio-player {:style {:padding "10px" :border-bottom "1px solid #ddd"}}
-   [:h3 {:style {:margin-bottom "10px"}} "Audio Player"]
+  (let [audio-player (get-in @state/app-state [:audio :player])
+        is-playing? (get-in @state/app-state [:audio :is-playing])
+        current-time (get-in @state/app-state [:audio :current-time])
+        duration (get-in @state/app-state [:audio :duration])]
+    [:div.audio-player {:style {:padding "10px" :border-bottom "1px solid #ddd"}}
+     [:h3 {:style {:margin-bottom "10px"}} "Audio Player"]
    
-   ;; File upload
-   [:div {:style {:margin-bottom "10px"}}
-    [:input
-     {:type "file"
-      :accept "audio/*"
-      :style {:font-size "12px"}
-      :on-change (fn [e]
-                   ;; TODO: Load audio file via player
-                   (.log js/console "File selected:" (-> e .-target .-files (aget 0))))}]]
+     ;; File upload
+     [:div {:style {:margin-bottom "10px"}}
+      [:input
+       {:type "file"
+        :accept "audio/*"
+        :style {:font-size "12px"}
+        :on-change (fn [e]
+                     (let [file (-> e .-target .-files (aget 0))]
+                       (when (and audio-player file)
+                         (-> (player/load-audio-file audio-player file)
+                             (.catch (fn [err]
+                                       (.error js/console "Failed to load audio file:" err)))))))}]]
    
-   ;; Playback controls
-   [:div {:style {:display "flex" :gap "5px" :margin-bottom "10px"}}
-    [:button
-     {:on-click #(.log js/console "Play")
-      :style {:padding "5px 10px" :cursor "pointer"}}
-     "▶ Play"]
-    [:button
-     {:on-click #(.log js/console "Pause")
-      :style {:padding "5px 10px" :cursor "pointer"}}
-     "⏸ Pause"]
-    [:button
-     {:on-click #(.log js/console "Stop")
-      :style {:padding "5px 10px" :cursor "pointer"}}
-     "⏹ Stop"]]
+     ;; Playback controls
+     [:div {:style {:display "flex" :gap "5px" :margin-bottom "10px"}}
+      [:button
+       {:on-click #(when audio-player (player/play audio-player))
+        :disabled (nil? audio-player)
+        :style {:padding "5px 10px" :cursor "pointer"}}
+       (if is-playing? "▶ Resume" "▶ Play")]
+      [:button
+       {:on-click #(when audio-player (player/pause audio-player))
+        :disabled (nil? audio-player)
+        :style {:padding "5px 10px" :cursor "pointer"}}
+       "⏸ Pause"]
+      [:button
+       {:on-click #(when audio-player (player/stop audio-player))
+        :disabled (nil? audio-player)
+        :style {:padding "5px 10px" :cursor "pointer"}}
+       "⏹ Stop"]]
    
-   ;; Time display and seek
-   [:div {:style {:display "flex" :align-items "center" :gap "5px" :font-size "12px"}}
-    [:span "0:00 / 0:00"]
-    [:input
-     {:type "range"
-      :min 0
-      :max 100
-      :default-value 0
-      :style {:flex 1 :cursor "pointer"}}]]])
+     ;; Time display and seek
+     [:div {:style {:display "flex" :align-items "center" :gap "5px" :font-size "12px"}}
+      [:span (str (.toFixed current-time 1) " / " (.toFixed duration 1) "s")]
+      [:input
+       {:type "range"
+        :min 0
+        :max (max duration 0.001)
+        :value (min current-time (max duration 0.001))
+        :step 0.01
+        :disabled (or (nil? audio-player) (<= duration 0))
+        :on-change #(when audio-player
+                      (player/seek audio-player (js/parseFloat (-> % .-target .-value))))
+        :style {:flex 1 :cursor "pointer"}}]]]))
 
 ;; ============================================================================
 ;; Visualizer Settings Component
@@ -56,7 +81,10 @@
 (defn visualizer-settings
   "Settings for the selected visualizer."
   [canvas-id]
-  (let [available-viz (registry/get-available-visualizers)]
+  (let [available-viz (registry/get-available-visualizers)
+        selected-viz (or (some-> (canvas-model/find-node (get-in @state/app-state [:layout :root]) canvas-id)
+                                 :visualizer-type)
+                         :waveform)]
     [:div.visualizer-settings {:style {:padding "10px" :border-bottom "1px solid #ddd"}}
      [:h4 {:style {:margin-bottom "10px"}} (str "Canvas " canvas-id " Settings")]
      
@@ -66,7 +94,10 @@
        "Visualizer Type:"]
       [:select
        {:style {:width "100%" :padding "5px" :font-size "12px"}
-        :on-change #(.log js/console "Visualizer changed:" (-> % .-target .-value))}
+        :value (name selected-viz)
+        :on-change #(state/dispatch :change-visualizer
+                                    canvas-id
+                                    (keyword (-> % .-target .-value)))}
        (for [{:keys [type name]} available-viz]
          ^{:key type}
          [:option {:value (name type)} name])]]
@@ -82,18 +113,23 @@
 (defn volume-control
   "Volume slider control."
   []
-  [:div {:style {:padding "10px" :border-bottom "1px solid #ddd"}}
+  (let [audio-player (get-in @state/app-state [:audio :player])
+        volume (get-in @state/app-state [:audio :volume])]
+    [:div {:style {:padding "10px" :border-bottom "1px solid #ddd"}}
    [:label {:style {:font-size "12px" :display "block" :margin-bottom "5px"}}
     "Volume:"]
    [:input
     {:type "range"
      :min 0
      :max 100
-     :default-value 100
+     :value (* 100 volume)
      :style {:width "100%"}
-     :on-change #(.log js/console "Volume changed:" (-> % .-target .-value))}]
+     :on-change #(let [v (/ (js/parseFloat (-> % .-target .-value)) 100)]
+                   (state/dispatch :set-volume v)
+                   (when audio-player
+                     (player/set-volume audio-player v)))}]
    [:span {:style {:font-size "11px" :color "#666"}}
-    " 100%"]])
+    (str " " (int (* 100 volume)) "%")]]))
 
 ;; ============================================================================
 ;; Main Control Panel Component
@@ -102,7 +138,8 @@
 (defn control-panel
   "Main control panel component with audio and visualizer controls."
   []
-  (let [show? (r/cursor state/app-state [:ui :show-control-panel])]
+  (let [show? (r/cursor state/app-state [:ui :show-control-panel])
+        layout-root (r/cursor state/app-state [:layout :root])]
     [:div.control-panel
      {:style {:position "fixed"
               :right (if @show? "0" "-300px")
@@ -135,10 +172,9 @@
       [volume-control]
       
       ;; Show visualizer settings for each canvas
-      [:div {:style {:padding "10px" :font-size "12px" :color "#666"}}
-       "Canvas-specific settings coming soon"]
-      
-      [visualizer-settings 0]]
+      (for [canvas-id (canvas-ids-from-layout @layout-root)]
+        ^{:key canvas-id}
+        [visualizer-settings canvas-id])]]
      
      ;; Toggle button outside (for hidden state)
      (when-not @show?


### PR DESCRIPTION
### Motivation
- Centralize audio playback metadata and controls in the app state so the control panel can display and control playback and volume.
- Move canvas split/remove/change-visualizer logic into the state update path to keep UI components thin and the layout model authoritative.
- Expose visualizer settings per-canvas and render them dynamically in the control panel based on the current layout tree.

### Description
- Add audio fields `:current-time` and `:volume` to `app-state`, introduce helper `canvas-ids`, and require `canvas.model` in `app.state` for layout operations.
- Add new `dispatch` actions in `app.state`: `:set-audio-player`, `:set-sample-puller`, `:set-current-time`, `:set-volume`, and implement `:split-canvas`, `:remove-canvas`, `:change-visualizer`, and `:update-visualizer-settings` to use `canvas.model` and to prune/update `:visualizers :instances` accordingly.
- Wire player initialization in `audio/player.cljs` to dispatch `:set-audio-player` and `:set-sample-puller`, and update `load-audio-file` to initialize `:current-time`, and attach `ontimeupdate`/`onended` handlers that dispatch `:set-current-time` and `:set-playing` respectively.
- Simplify `canvas.view` to dispatch `:split-canvas` and `:remove-canvas` instead of manipulating layout directly, and subscribe to `state/app-state` layout changes to keep the component in sync.
- Enhance `ui.control-panel.cljs` to: wire file upload to `player/load-audio-file`, add playback buttons calling `player/play`, `player/pause`, and `player/stop`, show live time and seek slider bound to `:current-time` and `:duration` with seek calling `player/seek`, add volume slider bound to `:volume` that calls `player/set-volume`, and render `visualizer-settings` for each canvas discovered via the layout tree.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65dc5878483298dfa7d22b8144993)