### PR TITLE
Add visualizer engine and integrate audio/player state with control panel and canvas management

### DIFF
--- a/clojure/src/app/init.cljs
+++ b/clojure/src/app/init.cljs
@@ -5,6 +5,7 @@
   (:require [app.state :as state]
             [audio.player :as player]
             [app.core :as app-core]
+            [visualizers.engine :as viz-engine]
             [reagent.core :as reagent]))
 
 ;; ============================================================================
@@ -111,6 +112,7 @@
       (.then (fn [player]
                ;; Mount the React app
                (mount-app)
+               (viz-engine/start!)
                (.log js/console "✅ App ready!")))
       (.catch (fn [error]
                 (.error js/console "😞 Startup failed:" error)))))

--- a/clojure/src/app/state.cljs
+++ b/clojure/src/app/state.cljs
@@ -18,7 +18,8 @@
          :settings {}}
     :visualizers {:instances {}  ;; {canvas-id -> visualizer instance}}
     :samples {:channels {}}})"
-  (:require [reagent.core :as r]))
+  (:require [reagent.core :as r]
+            [canvas.model :as model]))
 
 ;; Central application state atom
 (defonce app-state
@@ -28,6 +29,8 @@
             :sample-puller nil
             :sample-rate 0
             :duration 0
+            :current-time 0
+            :volume 1.0
             :is-playing false}
     :layout {:root {:type :canvas
                     :id 0
@@ -38,7 +41,12 @@
     :ui {:show-control-panel false
          :settings {}}
     :visualizers {:instances {}}
+    :canvas-elements {}
     :samples {:channels {}}}))
+
+(defn- canvas-ids
+  [layout-root]
+  (vec (model/get-all-canvas-ids layout-root)))
 
 ;; Dispatch functions for state updates
 (defn dispatch
@@ -52,10 +60,26 @@
     :set-sample-rate
     (let [[rate] args]
       (swap! app-state assoc-in [:audio :sample-rate] rate))
+
+    :set-audio-player
+    (let [[player] args]
+      (swap! app-state assoc-in [:audio :player] player))
+
+    :set-sample-puller
+    (let [[sample-puller] args]
+      (swap! app-state assoc-in [:audio :sample-puller] sample-puller))
     
     :set-duration
     (let [[duration] args]
       (swap! app-state assoc-in [:audio :duration] duration))
+
+    :set-current-time
+    (let [[current-time] args]
+      (swap! app-state assoc-in [:audio :current-time] current-time))
+
+    :set-volume
+    (let [[volume] args]
+      (swap! app-state assoc-in [:audio :volume] volume))
     
     :set-playing
     (let [[playing] args]
@@ -63,28 +87,65 @@
     
     :toggle-control-panel
     (swap! app-state update-in [:ui :show-control-panel] not)
+
+    :register-canvas-element
+    (let [[canvas-id canvas-el] args]
+      (swap! app-state assoc-in [:canvas-elements canvas-id] canvas-el))
+
+    :unregister-canvas-element
+    (let [[canvas-id] args]
+      (swap! app-state update :canvas-elements dissoc canvas-id))
     
     :split-canvas
     (let [[canvas-id orientation] args]
-      ;; Note: Canvas split logic is handled in canvas.view
-      ;; (this is a placeholder for state updates if needed)
-      )
+      (swap! app-state
+             (fn [s]
+               (let [next-id (get-in s [:layout :canvas-counter])
+                     current-layout (get-in s [:layout :root])
+                     new-layout (model/split-canvas current-layout canvas-id orientation next-id)]
+                 (if (nil? new-layout)
+                   s
+                   (-> s
+                       (assoc-in [:layout :root] new-layout)
+                       (update-in [:layout :canvas-counter] inc)))))))
     
     :remove-canvas
     (let [[canvas-id] args]
-      ;; Note: Canvas removal logic is handled in canvas.view
-      ;; (this is a placeholder for state updates if needed)
-      )
+      (swap! app-state
+             (fn [s]
+               (let [current-layout (get-in s [:layout :root])
+                     new-layout (model/remove-canvas current-layout canvas-id)]
+                 (if (nil? new-layout)
+                   s
+                   (let [remaining-ids (set (canvas-ids new-layout))]
+                     (-> s
+                         (assoc-in [:layout :root] new-layout)
+                         (update-in [:visualizers :instances]
+                                    (fn [m]
+                                      (into {}
+                                            (filter (fn [[id _]] (contains? remaining-ids id)) m)))))))))))
     
     :change-visualizer
     (let [[canvas-id visualizer-type] args]
-      ;; Note: Handled in canvas.view
-      )
+      (swap! app-state
+             (fn [s]
+               (-> s
+                   (update-in [:layout :root] model/change-canvas-visualizer canvas-id visualizer-type)
+                   (assoc-in [:visualizers :instances canvas-id]
+                             {:type visualizer-type
+                              :settings {}}))))
     
     :update-visualizer-settings
     (let [[canvas-id settings] args]
-      ;; Note: Handled in canvas.view
-      )
+      (swap! app-state
+             (fn [s]
+               (-> s
+                   (update-in [:layout :root] model/update-canvas-settings canvas-id settings)
+                   (update-in [:visualizers :instances canvas-id :settings]
+                              (fn [existing]
+                                (if (fn? settings)
+                                  (settings (or existing {}))
+                                  (merge (or existing {}) settings))))))))
     
     (do
       (.warn js/console "Unknown action:" action))))

--- a/clojure/src/audio/player.cljs
+++ b/clojure/src/audio/player.cljs
@@ -59,6 +59,8 @@
                         ;; Update app state with audio context
                         (state/dispatch :init-audio audio-context)
                         (state/dispatch :set-sample-rate (interop/get-sample-rate audio-context))
+                        (state/dispatch :set-audio-player player)
+                        (state/dispatch :set-sample-puller sp)
                         
                         (resolve player))))
              (.catch reject)))
@@ -93,8 +95,16 @@
                           (fn []
                             (let [duration (interop/get-audio-element-duration audio-element)]
                               (state/dispatch :set-duration duration))
-                            (remove-property audio-element "onloadedmetadata")
+                            (state/dispatch :set-current-time 0)
+                            (set! (.-onloadedmetadata audio-element) nil)
                             (resolve audio-element)))
+                    (set! (.-ontimeupdate audio-element)
+                          (fn []
+                            (state/dispatch :set-current-time
+                                            (interop/get-audio-element-current-time audio-element))))
+                    (set! (.-onended audio-element)
+                          (fn []
+                            (state/dispatch :set-playing false)))
                     
                     ;; Handle load errors
                     (set! (.-onerror audio-element)

--- a/clojure/src/canvas/view.cljs
+++ b/clojure/src/canvas/view.cljs
@@ -4,8 +4,7 @@
    Renders the layout tree as DOM elements with flexbox, canvas elements,
    and interactive controls (split, remove, resize)."
   (:require [reagent.core :as r]
-            [app.state :as state]
-            [canvas.model :as model]))
+            [app.state :as state]))
 
 ;; ============================================================================
 ;; Helper functions
@@ -13,7 +12,7 @@
 
 (defn canvas-element
   "Create a canvas DOM element with sizing."
-  []
+  [canvas-id]
   (let [el (r/atom nil)]
     (r/create-class
      {:component-did-mount
@@ -22,6 +21,7 @@
         (reset! el (r/dom-node this))
         
         ;; Set up ResizeObserver to track canvas size changes
+        (state/dispatch :register-canvas-element canvas-id @el)
         (when (exists? js/ResizeObserver)
           (let [observer (js/ResizeObserver.
                          (fn [entries]
@@ -34,6 +34,10 @@
                                (set! (.-width canvas) (int width))
                                (set! (.-height canvas) (int height))))))]
             (.observe observer @el))))
+
+      :component-will-unmount
+      (fn []
+        (state/dispatch :unregister-canvas-element canvas-id))
       
       :reagent-render
       (fn []
@@ -88,7 +92,7 @@
    ;; Canvas element
    [:div
     {:style {:flex 1 :overflow "hidden"}}
-    [canvas-element]]])
+    [canvas-element canvas-id]]])
 
 (declare layout-tree-view)
 
@@ -172,24 +176,9 @@
       :reagent-render
       (fn []
         (let [on-split (fn [canvas-id orientation]
-                         ;; Get next available ID
-                         (let [next-id (state/get-next-canvas-id)]
-                           ;; Update app state with new layout
-                           (swap! state/app-state
-                                  (fn [app-state]
-                                    (let [current-layout (get-in app-state [:layout :root])
-                                          new-layout (model/split-canvas current-layout canvas-id orientation next-id)]
-                                      (assoc-in app-state [:layout :root] new-layout))))))
-              
+                         (state/dispatch :split-canvas canvas-id orientation))
               on-remove (fn [canvas-id]
-                          ;; Update app state by removing canvas
-                          (swap! state/app-state
-                                 (fn [app-state]
-                                   (let [current-layout (get-in app-state [:layout :root])
-                                         new-layout (model/remove-canvas current-layout canvas-id)]
-                                     (if new-layout
-                                       (assoc-in app-state [:layout :root] new-layout)
-                                       app-state)))))]
+                          (state/dispatch :remove-canvas canvas-id))]
           
           [:div.canvas-manager
            {:style {:display "flex"

--- a/clojure/src/ui/control_panel.cljs
+++ b/clojure/src/ui/control_panel.cljs
@@ -2,7 +2,18 @@
   "Control panel UI component for adjusting audio and visualizer settings."
   (:require [reagent.core :as r]
             [app.state :as state]
+            [audio.player :as player]
+            [canvas.model :as canvas-model]
             [visualizers.registry :as registry]))
+
+(defn- canvas-ids-from-layout
+  [node]
+  (cond
+    (nil? node) []
+    (= (:type node) :canvas) [(:id node)]
+    (= (:type node) :split) (concat (canvas-ids-from-layout (:left node))
+                                    (canvas-ids-from-layout (:right node)))
+    :else []))
 
 ;; ============================================================================
 ;; Audio Player Control Component
@@ -11,43 +22,57 @@
 (defn audio-player-controls
   "UI controls for audio playback (file upload, play, pause, seek)."
   []
-  [:div.audio-player {:style {:padding "10px" :border-bottom "1px solid #ddd"}}
-   [:h3 {:style {:margin-bottom "10px"}} "Audio Player"]
+  (let [audio-player (get-in @state/app-state [:audio :player])
+        is-playing? (get-in @state/app-state [:audio :is-playing])
+        current-time (get-in @state/app-state [:audio :current-time])
+        duration (get-in @state/app-state [:audio :duration])]
+    [:div.audio-player {:style {:padding "10px" :border-bottom "1px solid #ddd"}}
+     [:h3 {:style {:margin-bottom "10px"}} "Audio Player"]
    
-   ;; File upload
-   [:div {:style {:margin-bottom "10px"}}
-    [:input
-     {:type "file"
-      :accept "audio/*"
-      :style {:font-size "12px"}
-      :on-change (fn [e]
-                   ;; TODO: Load audio file via player
-                   (.log js/console "File selected:" (-> e .-target .-files (aget 0))))}]]
+     ;; File upload
+     [:div {:style {:margin-bottom "10px"}}
+      [:input
+       {:type "file"
+        :accept "audio/*"
+        :style {:font-size "12px"}
+        :on-change (fn [e]
+                     (let [file (-> e .-target .-files (aget 0))]
+                       (when (and audio-player file)
+                         (-> (player/load-audio-file audio-player file)
+                             (.catch (fn [err]
+                                       (.error js/console "Failed to load audio file:" err)))))))}]]
    
-   ;; Playback controls
-   [:div {:style {:display "flex" :gap "5px" :margin-bottom "10px"}}
-    [:button
-     {:on-click #(.log js/console "Play")
-      :style {:padding "5px 10px" :cursor "pointer"}}
-     "▶ Play"]
-    [:button
-     {:on-click #(.log js/console "Pause")
-      :style {:padding "5px 10px" :cursor "pointer"}}
-     "⏸ Pause"]
-    [:button
-     {:on-click #(.log js/console "Stop")
-      :style {:padding "5px 10px" :cursor "pointer"}}
-     "⏹ Stop"]]
+     ;; Playback controls
+     [:div {:style {:display "flex" :gap "5px" :margin-bottom "10px"}}
+      [:button
+       {:on-click #(when audio-player (player/play audio-player))
+        :disabled (nil? audio-player)
+        :style {:padding "5px 10px" :cursor "pointer"}}
+       (if is-playing? "▶ Resume" "▶ Play")]
+      [:button
+       {:on-click #(when audio-player (player/pause audio-player))
+        :disabled (nil? audio-player)
+        :style {:padding "5px 10px" :cursor "pointer"}}
+       "⏸ Pause"]
+      [:button
+       {:on-click #(when audio-player (player/stop audio-player))
+        :disabled (nil? audio-player)
+        :style {:padding "5px 10px" :cursor "pointer"}}
+       "⏹ Stop"]]
    
-   ;; Time display and seek
-   [:div {:style {:display "flex" :align-items "center" :gap "5px" :font-size "12px"}}
-    [:span "0:00 / 0:00"]
-    [:input
-     {:type "range"
-      :min 0
-      :max 100
-      :default-value 0
-      :style {:flex 1 :cursor "pointer"}}]]])
+     ;; Time display and seek
+     [:div {:style {:display "flex" :align-items "center" :gap "5px" :font-size "12px"}}
+      [:span (str (.toFixed current-time 1) " / " (.toFixed duration 1) "s")]
+      [:input
+       {:type "range"
+        :min 0
+        :max (max duration 0.001)
+        :value (min current-time (max duration 0.001))
+        :step 0.01
+        :disabled (or (nil? audio-player) (<= duration 0))
+        :on-change #(when audio-player
+                      (player/seek audio-player (js/parseFloat (-> % .-target .-value))))
+        :style {:flex 1 :cursor "pointer"}}]]]))
 
 ;; ============================================================================
 ;; Visualizer Settings Component
@@ -56,7 +81,10 @@
 (defn visualizer-settings
   "Settings for the selected visualizer."
   [canvas-id]
-  (let [available-viz (registry/get-available-visualizers)]
+  (let [canvas-node (canvas-model/find-node (get-in @state/app-state [:layout :root]) canvas-id)
+        available-viz (registry/get-available-visualizers)
+        selected-viz (or (:visualizer-type canvas-node) :waveform)
+        settings (or (:settings canvas-node) {})]
     [:div.visualizer-settings {:style {:padding "10px" :border-bottom "1px solid #ddd"}}
      [:h4 {:style {:margin-bottom "10px"}} (str "Canvas " canvas-id " Settings")]
      
@@ -66,14 +94,51 @@
        "Visualizer Type:"]
       [:select
        {:style {:width "100%" :padding "5px" :font-size "12px"}
-        :on-change #(.log js/console "Visualizer changed:" (-> % .-target .-value))}
+        :value (name selected-viz)
+        :on-change #(state/dispatch :change-visualizer
+                                    canvas-id
+                                    (keyword (-> % .-target .-value)))}
        (for [{:keys [type name]} available-viz]
          ^{:key type}
          [:option {:value (name type)} name])]]
      
-     ;; Visualizer-specific settings (placeholder)
-     [:div {:style {:background "#f0f0f0" :padding "5px" :border-radius "3px" :font-size "11px"}}
-      [:p "Visualizer-specific settings (TODO)"]]]))
+     ;; Visualizer-specific settings
+     [:div {:style {:background "#f0f0f0" :padding "8px" :border-radius "3px" :font-size "11px"}}
+      (case selected-viz
+        :waveform
+        [:<>
+         [:label {:style {:display "block" :margin-bottom "4px"}} "Buffer Size"]
+         [:input {:type "number"
+                  :min 128 :max 8192 :step 128
+                  :value (or (:buffer-size settings) 2048)
+                  :on-change #(state/dispatch :update-visualizer-settings
+                                              canvas-id
+                                              {:buffer-size (js/parseInt (-> % .-target .-value))})}]
+         [:label {:style {:display "block" :margin "6px 0 4px"}} "Line Width"]
+         [:input {:type "number"
+                  :min 1 :max 8 :step 1
+                  :value (or (:line-width settings) 1)
+                  :on-change #(state/dispatch :update-visualizer-settings
+                                              canvas-id
+                                              {:line-width (js/parseInt (-> % .-target .-value))})}]
+         [:label {:style {:display "block" :margin "6px 0 4px"}} "Line Color"]
+         [:input {:type "color"
+                  :value (or (:line-color settings) "#00ff00")
+                  :on-change #(state/dispatch :update-visualizer-settings
+                                              canvas-id
+                                              {:line-color (-> % .-target .-value)})}]]
+
+        :stft
+        [:<>
+         [:label {:style {:display "block" :margin-bottom "4px"}} "FFT Size"]
+         [:select {:value (str (or (:fft-size settings) 512))
+                   :on-change #(state/dispatch :update-visualizer-settings
+                                               canvas-id
+                                               {:fft-size (js/parseInt (-> % .-target .-value))})}
+          (for [n [256 512 1024 2048 4096]]
+            ^{:key n} [:option {:value n} n])]]
+
+        [:p "No settings for this visualizer."])]]))
 
 ;; ============================================================================
 ;; Volume Control Component
@@ -82,18 +147,23 @@
 (defn volume-control
   "Volume slider control."
   []
-  [:div {:style {:padding "10px" :border-bottom "1px solid #ddd"}}
+  (let [audio-player (get-in @state/app-state [:audio :player])
+        volume (get-in @state/app-state [:audio :volume])]
+    [:div {:style {:padding "10px" :border-bottom "1px solid #ddd"}}
    [:label {:style {:font-size "12px" :display "block" :margin-bottom "5px"}}
     "Volume:"]
    [:input
     {:type "range"
      :min 0
      :max 100
-     :default-value 100
+     :value (* 100 volume)
      :style {:width "100%"}
-     :on-change #(.log js/console "Volume changed:" (-> % .-target .-value))}]
+     :on-change #(let [v (/ (js/parseFloat (-> % .-target .-value)) 100)]
+                   (state/dispatch :set-volume v)
+                   (when audio-player
+                     (player/set-volume audio-player v)))}]
    [:span {:style {:font-size "11px" :color "#666"}}
-    " 100%"]])
+    (str " " (int (* 100 volume)) "%")]]))
 
 ;; ============================================================================
 ;; Main Control Panel Component
@@ -102,7 +172,8 @@
 (defn control-panel
   "Main control panel component with audio and visualizer controls."
   []
-  (let [show? (r/cursor state/app-state [:ui :show-control-panel])]
+  (let [show? (r/cursor state/app-state [:ui :show-control-panel])
+        layout-root (r/cursor state/app-state [:layout :root])]
     [:div.control-panel
      {:style {:position "fixed"
               :right (if @show? "0" "-300px")
@@ -135,10 +206,9 @@
       [volume-control]
       
       ;; Show visualizer settings for each canvas
-      [:div {:style {:padding "10px" :font-size "12px" :color "#666"}}
-       "Canvas-specific settings coming soon"]
-      
-      [visualizer-settings 0]]
+      (for [canvas-id (canvas-ids-from-layout @layout-root)]
+        ^{:key canvas-id}
+        [visualizer-settings canvas-id])]]
      
      ;; Toggle button outside (for hidden state)
      (when-not @show?

--- a/clojure/src/visualizers/engine.cljs
+++ b/clojure/src/visualizers/engine.cljs
@@ -1,0 +1,89 @@
+(ns visualizers.engine
+  "Visualizer runtime loop that renders active visualizers per canvas."
+  (:require [app.state :as state]
+            [canvas.model :as canvas-model]
+            [visualizers.registry :as registry]
+            [visualizers.protocol :as protocol]))
+
+(defonce running? (atom false))
+(defonce raf-id (atom nil))
+
+(defn- layout-canvas-nodes
+  [node]
+  (cond
+    (nil? node) []
+    (= (:type node) :canvas) [node]
+    (= (:type node) :split) (concat (layout-canvas-nodes (:left node))
+                                    (layout-canvas-nodes (:right node)))
+    :else []))
+
+(defn- ensure-visualizer-instance!
+  [canvas-id visualizer-type settings]
+  (let [existing-entry (get-in @state/app-state [:visualizers :instances canvas-id])
+        existing (:instance existing-entry)
+        existing-type (:type existing-entry)]
+    (when (or (nil? existing) (not= existing-type visualizer-type))
+      (if-let [instance (apply registry/create-visualizer visualizer-type (mapcat identity settings))]
+        (swap! state/app-state assoc-in [:visualizers :instances canvas-id]
+               {:type visualizer-type
+                :settings settings
+                :instance instance})
+        (.warn js/console "Failed to create visualizer for" canvas-id visualizer-type)))))
+
+(defn- sync-visualizer-settings!
+  [canvas-id settings]
+  (when-let [viz (get-in @state/app-state [:visualizers :instances canvas-id :instance])]
+    (let [current-settings (protocol/get-settings viz)]
+      (when (not= current-settings settings)
+        (let [updated (protocol/update-settings viz settings)]
+          (swap! state/app-state assoc-in [:visualizers :instances canvas-id :instance] updated))))))
+
+(defn- render-step!
+  []
+  (let [s @state/app-state
+        layout-root (get-in s [:layout :root])
+        sample-puller (get-in s [:audio :sample-puller])
+        canvas-elements (:canvas-elements s)
+        nodes (layout-canvas-nodes layout-root)
+        active-ids (set (map :id nodes))]
+
+    ;; Remove orphan visualizer instances
+    (swap! state/app-state update-in [:visualizers :instances]
+           (fn [instances]
+             (into {}
+                   (filter (fn [[id _]] (contains? active-ids id)) instances))))
+
+    ;; Render all active canvas visualizers
+    (doseq [node nodes]
+      (let [canvas-id (:id node)
+            canvas-el (get canvas-elements canvas-id)
+            visualizer-type (or (:visualizer-type node) :waveform)
+            settings (or (:settings node) {})]
+        (when (and canvas-el sample-puller)
+          (ensure-visualizer-instance! canvas-id visualizer-type settings)
+          (sync-visualizer-settings! canvas-id settings)
+          (swap! state/app-state assoc-in [:visualizers :instances canvas-id :settings] settings)
+          (when-let [viz (get-in @state/app-state [:visualizers :instances canvas-id :instance])]
+            (protocol/render viz canvas-el sample-puller)))))))
+
+(defn- tick!
+  []
+  (when @running?
+    (render-step!)
+    (reset! raf-id (js/requestAnimationFrame tick!))))
+
+(defn start!
+  []
+  (when-not @running?
+    (reset! running? true)
+    (reset! raf-id (js/requestAnimationFrame tick!))
+    (.log js/console "Visualizer engine started")))
+
+(defn stop!
+  []
+  (when @running?
+    (reset! running? false)
+    (when-let [id @raf-id]
+      (js/cancelAnimationFrame id))
+    (reset! raf-id nil)
+    (.log js/console "Visualizer engine stopped")))

--- a/clojure/src/visualizers/registry.cljs
+++ b/clojure/src/visualizers/registry.cljs
@@ -34,7 +34,7 @@
   [visualizer-type & {:as options}]
   (if-let [entry (get visualizer-registry visualizer-type)]
     (let [factory (:factory entry)]
-      (factory options))
+      (apply factory (mapcat identity options)))
     (do
       (.warn js/console "Unknown visualizer type:" visualizer-type)
       nil)))


### PR DESCRIPTION
### Motivation
- Introduce a rendering runtime to drive canvas-based visualizers and wire it into app startup so visualizations run automatically. 
- Centralize audio/player runtime state (current time, volume, sample-puller, player instance) so UI and render loop can react to playback. 
- Improve canvas lifecycle handling so canvas DOM nodes are tracked, visualizers are created/cleaned up, and per-canvas settings can be edited from the control panel. 

### Description
- Add `visualizers.engine` which implements a RAF-driven render loop that discovers canvas nodes, ensures visualizer instances via `visualizers.registry`, syncs settings, and calls the visualizer `render` protocol; also provides `start!`/`stop!` functions. 
- Extend `app.state` with audio fields `:current-time` and `:volume`, a `:canvas-elements` map, and richer `:visualizers :instances` management plus new dispatch actions such as `:set-audio-player`, `:set-sample-puller`, `:set-current-time`, `:set-volume`, `:register-canvas-element`, `:unregister-canvas-element`, `:split-canvas`, `:remove-canvas`, `:change-visualizer`, and `:update-visualizer-settings`. 
- Update `audio.player` to store the created `AudioPlayer` and `SamplePuller` in state, wire `onloadedmetadata`, `ontimeupdate`, and `onended` handlers, and dispatch duration/current-time/playing state changes. 
- Update `canvas.view` to register/unregister canvas DOM nodes with state and route split/remove actions through the new state dispatches so layout and visualizer lifecycle are managed centrally. 
- Enhance `ui.control-panel` to wire file upload, play/pause/stop, seek and volume UI to the audio player via `audio.player` helpers, present per-canvas visualizer settings (with type selector and specific options for `:waveform` and `:stft`), and enumerate canvas settings dynamically from the layout. 
- Fix `visualizers.registry/create-visualizer` argument passing so factory functions receive option map arguments. 
- Start the visualizer engine during app initialization in `app.init` by calling `visualizers.engine/start!`. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65dc5878483298dfa7d22b8144993)