### PR TITLE
Align build output to main.js, add serve scripts, and update docs

### DIFF
--- a/clojure/QUICKSTART.md
+++ b/clojure/QUICKSTART.md
@@ -33,7 +33,14 @@ java -version
 
 ## Running the App
 
-### Option 1: Single Command (Recommended)
+## Script Reference
+
+- `npm run dev`: Watches and recompiles ClojureScript for development (`public/js/main.js`).
+- `npm run serve:dev`: Serves static files from `public/` on port 8000.
+- `npm run serve:release`: Builds optimized release output (`public/js/main.js`) and serves it.
+- `npm run serve`: Alias for `serve:dev`.
+
+### Development (Recommended)
 
 ```bash
 cd clojure
@@ -42,14 +49,14 @@ npm run dev
 
 Then in a new terminal:
 ```bash
-npm run serve
+npm run serve:dev
 ```
 
 Open http://localhost:8000 in your browser.
 
 **Note:** The `npm run dev` command watches for file changes and auto-recompiles. Your browser will hot-reload.
 
-### Option 2: Step by Step
+### Development (Step by Step)
 
 **Terminal 1 - Build/Watch:**
 ```bash
@@ -108,7 +115,12 @@ cd clojure
 npm run release
 ```
 
-Output: `public/js/app.js` (optimized & minified, ~50-100KB)
+To serve the release bundle locally:
+```bash
+npm run serve:release
+```
+
+Output: `public/js/main.js` (optimized & minified, ~50-100KB)
 
 ## Deployment to GitHub Pages
 
@@ -147,13 +159,13 @@ Just push to GitHub and check "Actions" tab for build status.
    ```
 
 3. **Verify files were compiled:**
-   - Check `clojure/public/js/app.js` exists and has content
+   - Check `clojure/public/js/main.js` exists and has content
 
-### "Cannot GET /js/app.js"
+### "Cannot GET /js/main.js"
 
 - The dev server isn't running, or
 - You're serving from wrong directory
-- Run `npm run serve` from `clojure/` directory
+- Run `npm run serve:dev` from `clojure/` directory
 
 ### REPL connection fails
 
@@ -166,7 +178,7 @@ Just push to GitHub and check "Actions" tab for build status.
 clojure/
 ├── public/
 │   ├── index.html           # Entry point
-│   ├── js/app.js            # Compiled output (generated)
+│   ├── js/main.js           # Compiled output (generated)
 │   └── sample_processor.js  # AudioWorklet code
 ├── src/
 │   ├── app/

--- a/clojure/README.md
+++ b/clojure/README.md
@@ -100,7 +100,7 @@ cd clojure
 clj -Ashadow release app
 ```
 
-Output: `public/js/app.js` (optimized & minified)
+Output: `public/js/main.js` (optimized & minified)
 
 ## Implementation Status
 

--- a/clojure/package.json
+++ b/clojure/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "shadow-cljs watch app",
     "release": "shadow-cljs release app",
-    "serve": "cd public && python3 -m http.server 8000"
+    "serve": "npm run serve:dev",
+    "serve:dev": "cd public && python3 -m http.server 8000",
+    "serve:release": "npm run release && npm run serve:dev"
   },
   "dependencies": {
     "fftjs": "^0.0.4",

--- a/clojure/public/index.html
+++ b/clojure/public/index.html
@@ -28,7 +28,7 @@
     </div>
     
     <!-- Shadow-cljs compiled output -->
-    <script src="/js/app.js"></script>
+    <script src="/js/main.js"></script>
     
     <!-- Initialize the app -->
     <script>

--- a/clojure/shadow-cljs.edn
+++ b/clojure/shadow-cljs.edn
@@ -9,6 +9,6 @@
    :devtools {:http-port 3000
               :http-host "127.0.0.1"}
    :release
-   {:output-to "public/js/app.js"
+   {:output-to "public/js/main.js"
     :output-wrapper false
     :source-map true}}}}


### PR DESCRIPTION
### Motivation
- Ensure the compiled artifact filename and local serve commands are consistent across build config, HTML, and docs. 
- Provide convenient npm scripts to serve development and release bundles and reduce confusion around `app.js` vs `main.js`.

### Description
- Changed Shadow-cljs release output to `public/js/main.js` in `shadow-cljs.edn` so the compiled module is `main.js`.
- Updated `public/index.html` to load `/js/main.js` instead of `/js/app.js`.
- Updated `README.md` and `QUICKSTART.md` to reference `main.js`, to document `npm run dev`, `npm run serve:dev`, and `npm run serve:release`, and to clarify development workflows.
- Modified `package.json` scripts to add `serve:dev` and `serve:release`, and made `serve` an alias for `serve:dev`.

### Testing
- No automated tests were added or modified for this change and the repository's existing CI workflow (`.github/workflows/deploy.yml`) remains unchanged and will run the build on pushes to `main`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66ec6310c832990173fee9c8a682e)